### PR TITLE
fix: Ensure immediate font application on canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,9 +392,27 @@
                     // drawOnCanvas가 비동기이므로 await 호출
                     await window.thumbnailRenderer.ThumbnailRenderer.drawOnCanvas(ctx, this.dslObj);
                 },
-                update() {
+                async update() {
                     this.dsl = this.generateDSL();
                     this.dslObj = JSON.parse(this.dsl);
+
+                    if (this.fontFamily && typeof document !== 'undefined' && document.fonts) { // Check for document.fonts support
+                        try {
+                            const fontString = `12px "${this.fontFamily}"`; // Use a common size for checking
+                            // console.log('Currently selected font:', this.fontFamily); // Debugging
+                            if (!document.fonts.check(fontString)) {
+                                // console.log(`Font "${this.fontFamily}" not immediately ready, attempting to load...`);
+                                await document.fonts.load(fontString);
+                                // console.log(`Font "${this.fontFamily}" loaded successfully.`);
+                            } else {
+                                // console.log(`Font "${this.fontFamily}" is already loaded/available.`);
+                            }
+                        } catch (error) {
+                            console.error(`Error loading font "${this.fontFamily}":`, error);
+                            // Optionally, handle the error, e.g., by selecting a default font or showing a message
+                            // For now, we'll just log it and proceed, potentially with a fallback font rendered by the browser.
+                        }
+                    }
                     // draw()만 호출 (renderer가 모든 환경에서 이미지 처리)
                     this.draw();
                 },


### PR DESCRIPTION
This commit addresses an issue where newly selected fonts, especially web fonts, might not apply immediately to the canvas due to font loading latency.

The `update()` method in `thumbnailApp` (index.html) has been made asynchronous. Before calling `draw()`, it now uses `document.fonts.check()` and `await document.fonts.load()` to ensure that the currently selected `fontFamily` is loaded and available for rendering.

This provides a better user experience by making font changes appear on the canvas promptly after selection from the dropdown or after adding a new custom font.