### PR TITLE
feat: Add independent styling options for subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,6 +249,31 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <!-- Subtitle Font Family Dropdown -->
+                                        <div class="mb-3">
+                                            <label class="form-label">폰트</label>
+                                            <select class="form-select" x-model="subtitleFontFamily" @change="update()">
+                                                <template x-for="f in fontFaces" :key="f.name">
+                                                    <option x-text="f.name" :value="f.name"></option>
+                                                </template>
+                                            </select>
+                                        </div>
+                                        <!-- Subtitle Font Size Input -->
+                                        <div class="mb-3">
+                                            <label class="form-label">폰트 크기</label>
+                                            <input type="number" class="form-control" x-model.number="subtitleFontSize" @input="update()" min="8" max="100">
+                                        </div>
+                                        <!-- Subtitle Outline Controls -->
+                                        <div class="row g-2 mb-3">
+                                            <div class="col d-flex align-items-center">
+                                                <input class="form-check-input" type="checkbox" x-model="subtitleOutline" @change="update()" id="subtitleOutlineCheck">
+                                                <label class="form-check-label ms-2" for="subtitleOutlineCheck">외곽선</label>
+                                            </div>
+                                            <div class="col d-flex align-items-center">
+                                                <input type="number" min="1" max="20" class="form-control ms-2" style="width:70px" x-model.number="subtitleOutlineThickness" :disabled="!subtitleOutline" @input="update()">
+                                                <span class="ms-1" style="font-size:0.9em;">px</span>
+                                            </div>
+                                        </div>
                                         <!-- Subtitle Font Style Controls -->
                                         <div class="row g-2 mb-3">
                                             <div class="col">
@@ -348,6 +373,10 @@
                 fixedRatioDrivingInput: 'width', // Or null
                 titleGridPosition: 'tl',
                 subtitleGridPosition: 'bl',
+                subtitleFontFamily: '', // New
+                subtitleFontSize: 24,    // New
+                subtitleOutline: false,  // New
+                subtitleOutlineThickness: 5, // New
                 dsl: '',
                 dslObj: null,
                 bgImageObj: null,
@@ -360,6 +389,7 @@
                         style: 'normal'
                     }];
                     this.fontFamily = this.fontFaces[0].name;
+                    this.subtitleFontFamily = this.fontFamily; // Initialize subtitle font
                     this.update();
                 },
                 parseAndAddFontFace() {
@@ -520,15 +550,15 @@
                             content: this.subtitleText,
                             gridPosition: this.subtitleGridPosition,
                             font: {
-                                name: this.fontFamily,
+                                name: this.subtitleFontFamily, // Changed
                                 faces: this.fontFaces
                             },
-                            fontSize: 24,
+                            fontSize: this.subtitleFontSize, // Changed
                             color: this.subtitleColor,
                             fontWeight: this.subtitleFontWeight,
                             fontStyle: this.subtitleFontStyle,
                             lineHeight: this.subtitleLineHeight,
-                            outline: null,
+                            outline: this.subtitleOutline ? { thickness: this.subtitleOutlineThickness, color: '#000' } : null, // Changed
                             enabled: true
                         });
                     }


### PR DESCRIPTION
This commit enhances subtitle customization by providing it with its own set of styling controls, independent of the main title's settings. Subtitles can now have a distinct font family, font size, and outline.

Key changes:

- Updated `index.html`:
    - Data Model (`thumbnailApp`): - Added `subtitleFontFamily`, `subtitleFontSize`, `subtitleOutline`, and `subtitleOutlineThickness` properties to the data model. - `subtitleFontFamily` is initialized to the global `fontFamily` to maintain previous behavior by default.
    - UI Changes ("Text Settings" for Subtitle):
        - Added a "폰트" (Font Family) dropdown for `subtitleFontFamily`.
        - Added a "폰트 크기" (Font Size) number input for `subtitleFontSize`. - Added "외곽선" (Outline) controls (checkbox and thickness input) for `subtitleOutline` and `subtitleOutlineThickness`. - These controls are similar in function to those for the title.
    - DSL Generation (`generateDSL`): - The subtitle text object in the DSL now populates `font.name` from `subtitleFontFamily`, `fontSize` from `subtitleFontSize`, and `outline` from `subtitleOutline` and `subtitleOutlineThickness` (with a default black color).

- Verified `thumbnailRenderer.js`:
    - Confirmed that the existing rendering logic for text properties (font family, size, outline) is generic and correctly applies these new distinct properties when present in the subtitle's DSL object. No changes to the renderer were necessary.

This allows for greater flexibility in styling subtitles independently from the main title, fulfilling your request for more granular control.